### PR TITLE
Add CRUD operations for materiais e ferramentas

### DIFF
--- a/springboot/demo/src/main/java/com/example/demo/api/controller/FerramentaController.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/controller/FerramentaController.java
@@ -3,11 +3,9 @@ package com.example.demo.api.controller;
 import com.example.demo.api.dto.FerramentaDTO;
 import com.example.demo.api.service.FerramentaService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,5 +26,28 @@ public class FerramentaController {
         return ferramentaService.buscarPorId(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<FerramentaDTO> criar(@RequestBody FerramentaDTO dto) {
+        FerramentaDTO criado = ferramentaService.criar(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FerramentaDTO> atualizar(@PathVariable Integer id,
+                                                   @RequestBody FerramentaDTO dto) {
+        return ferramentaService.atualizar(id, dto)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletar(@PathVariable Integer id) {
+        boolean removido = ferramentaService.deletar(id);
+        if (removido) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
     }
 }

--- a/springboot/demo/src/main/java/com/example/demo/api/controller/MaterialConstrucaoController.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/controller/MaterialConstrucaoController.java
@@ -3,11 +3,9 @@ package com.example.demo.api.controller;
 import com.example.demo.api.dto.MaterialConstrucaoDTO;
 import com.example.demo.api.service.MaterialConstrucaoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,5 +26,28 @@ public class MaterialConstrucaoController {
         return materialConstrucaoService.buscarPorId(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<MaterialConstrucaoDTO> criar(@RequestBody MaterialConstrucaoDTO dto) {
+        MaterialConstrucaoDTO criado = materialConstrucaoService.criar(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MaterialConstrucaoDTO> atualizar(@PathVariable Integer id,
+                                                           @RequestBody MaterialConstrucaoDTO dto) {
+        return materialConstrucaoService.atualizar(id, dto)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletar(@PathVariable Integer id) {
+        boolean removido = materialConstrucaoService.deletar(id);
+        if (removido) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
     }
 }

--- a/springboot/demo/src/main/java/com/example/demo/api/service/FerramentaService.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/service/FerramentaService.java
@@ -5,10 +5,12 @@ import com.example.demo.api.dto.FilialResumoDTO;
 import com.example.demo.api.model.FerramentaEntity;
 import com.example.demo.api.model.FilialEntity;
 import com.example.demo.api.repository.FerramentaRepository;
+import com.example.demo.api.repository.FilialRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +19,7 @@ import java.util.Optional;
 public class FerramentaService {
 
     private final FerramentaRepository ferramentaRepository;
+    private final FilialRepository filialRepository;
 
     @Transactional(readOnly = true)
     public List<FerramentaDTO> listarTodos() {
@@ -30,6 +33,55 @@ public class FerramentaService {
     public Optional<FerramentaDTO> buscarPorId(Integer id) {
         return ferramentaRepository.findById(id)
                 .map(this::mapearParaDTO);
+    }
+
+    @Transactional
+    public FerramentaDTO criar(FerramentaDTO dto) {
+        FerramentaEntity entity = new FerramentaEntity();
+        atualizarCampos(entity, dto);
+        FerramentaEntity salvo = ferramentaRepository.save(entity);
+        return mapearParaDTO(salvo);
+    }
+
+    @Transactional
+    public Optional<FerramentaDTO> atualizar(Integer id, FerramentaDTO dto) {
+        return ferramentaRepository.findById(id)
+                .map(entity -> {
+                    atualizarCampos(entity, dto);
+                    FerramentaEntity salvo = ferramentaRepository.save(entity);
+                    return mapearParaDTO(salvo);
+                });
+    }
+
+    @Transactional
+    public boolean deletar(Integer id) {
+        if (!ferramentaRepository.existsById(id)) {
+            return false;
+        }
+        ferramentaRepository.deleteById(id);
+        return true;
+    }
+
+    private void atualizarCampos(FerramentaEntity entity, FerramentaDTO dto) {
+        if (dto == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Dados da ferramenta são obrigatórios");
+        }
+
+        entity.setCodigoProduto(dto.getCodigoProduto());
+        entity.setValor(dto.getValor());
+        entity.setMarca(dto.getMarca());
+        entity.setNome(dto.getNome());
+        entity.setQtdPacote(dto.getQtdPacote());
+        entity.setFilial(obterFilial(dto.getFilial()));
+    }
+
+    private FilialEntity obterFilial(FilialResumoDTO filialResumoDTO) {
+        if (filialResumoDTO == null || filialResumoDTO.getIdLancamento() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Filial da ferramenta é obrigatória");
+        }
+
+        return filialRepository.findById(filialResumoDTO.getIdLancamento())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Filial não encontrada"));
     }
 
     private FerramentaDTO mapearParaDTO(FerramentaEntity entity) {

--- a/springboot/demo/src/main/java/com/example/demo/api/service/MaterialConstrucaoService.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/service/MaterialConstrucaoService.java
@@ -4,11 +4,13 @@ import com.example.demo.api.dto.FilialResumoDTO;
 import com.example.demo.api.dto.MaterialConstrucaoDTO;
 import com.example.demo.api.model.FilialEntity;
 import com.example.demo.api.model.MaterialConstrucaoEntity;
+import com.example.demo.api.repository.FilialRepository;
 import com.example.demo.api.repository.MaterialConstrucaoRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +19,7 @@ import java.util.Optional;
 public class MaterialConstrucaoService {
 
     private final MaterialConstrucaoRepository materialConstrucaoRepository;
+    private final FilialRepository filialRepository;
 
     @Transactional(readOnly = true)
     public List<MaterialConstrucaoDTO> listarTodos() {
@@ -30,6 +33,55 @@ public class MaterialConstrucaoService {
     public Optional<MaterialConstrucaoDTO> buscarPorId(Integer id) {
         return materialConstrucaoRepository.findById(id)
                 .map(this::mapearParaDTO);
+    }
+
+    @Transactional
+    public MaterialConstrucaoDTO criar(MaterialConstrucaoDTO dto) {
+        MaterialConstrucaoEntity entity = new MaterialConstrucaoEntity();
+        atualizarCampos(entity, dto);
+        MaterialConstrucaoEntity salvo = materialConstrucaoRepository.save(entity);
+        return mapearParaDTO(salvo);
+    }
+
+    @Transactional
+    public Optional<MaterialConstrucaoDTO> atualizar(Integer id, MaterialConstrucaoDTO dto) {
+        return materialConstrucaoRepository.findById(id)
+                .map(entity -> {
+                    atualizarCampos(entity, dto);
+                    MaterialConstrucaoEntity salvo = materialConstrucaoRepository.save(entity);
+                    return mapearParaDTO(salvo);
+                });
+    }
+
+    @Transactional
+    public boolean deletar(Integer id) {
+        if (!materialConstrucaoRepository.existsById(id)) {
+            return false;
+        }
+        materialConstrucaoRepository.deleteById(id);
+        return true;
+    }
+
+    private void atualizarCampos(MaterialConstrucaoEntity entity, MaterialConstrucaoDTO dto) {
+        if (dto == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Dados do material são obrigatórios");
+        }
+
+        entity.setCodigoProduto(dto.getCodigoProduto());
+        entity.setValor(dto.getValor());
+        entity.setCor(dto.getCor());
+        entity.setNome(dto.getNome());
+        entity.setMateriaPrima(dto.getMateriaPrima());
+        entity.setFilial(obterFilial(dto.getFilial()));
+    }
+
+    private FilialEntity obterFilial(FilialResumoDTO filialResumoDTO) {
+        if (filialResumoDTO == null || filialResumoDTO.getIdLancamento() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Filial do material é obrigatória");
+        }
+
+        return filialRepository.findById(filialResumoDTO.getIdLancamento())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Filial não encontrada"));
     }
 
     private MaterialConstrucaoDTO mapearParaDTO(MaterialConstrucaoEntity entity) {


### PR DESCRIPTION
## Summary
- add POST, PUT and DELETE endpoints to the material de construção and ferramenta controllers
- implement service-layer create/update/delete logic with filial validation for both recursos

## Testing
- ./mvnw -q test *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d809d2271483209e841b3a520ac207