### PR TITLE
Add CRUD endpoints for Filial resource

### DIFF
--- a/springboot/demo/src/main/java/com/example/demo/api/controller/FilialController.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/controller/FilialController.java
@@ -4,11 +4,9 @@ import com.example.demo.api.dto.FilialDetalheDTO;
 import com.example.demo.api.dto.FilialResumoDTO;
 import com.example.demo.api.service.FilialService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,5 +27,28 @@ public class FilialController {
         return filialService.buscarPorId(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<FilialDetalheDTO> criar(@RequestBody FilialResumoDTO dto) {
+        FilialDetalheDTO criado = filialService.criar(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FilialDetalheDTO> atualizar(@PathVariable Integer id,
+                                                      @RequestBody FilialResumoDTO dto) {
+        return filialService.atualizar(id, dto)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletar(@PathVariable Integer id) {
+        boolean removido = filialService.deletar(id);
+        if (removido) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
     }
 }


### PR DESCRIPTION
## Summary
- add POST, PUT and DELETE endpoints to the Filial controller
- implement create, update and delete workflows in FilialService with input validation

## Testing
- `./mvnw test` *(fails: Maven wrapper could not download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d84620c3f083209ee405eb168e714a