### PR TITLE
Configure MySQL auto increment for entity IDs

### DIFF
--- a/springboot/demo/src/main/java/com/example/demo/api/model/FerramentaEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/FerramentaEntity.java
@@ -11,7 +11,8 @@ public class FerramentaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CODIGO_FERRAMENTA")
+    @Column(name = "CODIGO_FERRAMENTA", nullable = false, updatable = false,
+            columnDefinition = "INT AUTO_INCREMENT")
     private Integer codFerramenta;
 
     @Column(name = "CODIGO_PRODUTO", length = 50, nullable = false)

--- a/springboot/demo/src/main/java/com/example/demo/api/model/FilialEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/FilialEntity.java
@@ -11,7 +11,9 @@ import java.util.List;
 public class FilialEntity {
 
     @Id
-    @Column(name = "CODIGO_FILIAL")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CODIGO_FILIAL", nullable = false, updatable = false,
+            columnDefinition = "INT AUTO_INCREMENT")
     private Integer idLancamento;
 
     @Column(name = "NOME_FILIAL", nullable = false, length = 150)

--- a/springboot/demo/src/main/java/com/example/demo/api/model/MaterialConstrucaoEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/MaterialConstrucaoEntity.java
@@ -11,7 +11,8 @@ public class MaterialConstrucaoEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CODIGO_MATERIAL")
+    @Column(name = "CODIGO_MATERIAL", nullable = false, updatable = false,
+            columnDefinition = "INT AUTO_INCREMENT")
     private Integer codMaterial;
 
     @Column(name = "CODIGO_PRODUTO", length = 50, nullable = false)


### PR DESCRIPTION
## Summary
- enforce MySQL AUTO_INCREMENT column definitions for the primary keys of filial, ferramenta, and material entities
- mark identifier columns as non-null and non-updatable to align with generated values

## Testing
- ./mvnw test *(fails: Network is unreachable while downloading Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d84964a8088320be5995fa1c973a5e