### PR TITLE
Fix filial creation auto increment behaviour

### DIFF
--- a/springboot/demo/src/main/java/com/example/demo/api/model/FerramentaEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/FerramentaEntity.java
@@ -11,7 +11,8 @@ public class FerramentaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CODIGO_FERRAMENTA")
+    @Column(name = "CODIGO_FERRAMENTA", nullable = false, updatable = false,
+            columnDefinition = "INT AUTO_INCREMENT")
     private Integer codFerramenta;
 
     @Column(name = "CODIGO_PRODUTO", length = 50, nullable = false)

--- a/springboot/demo/src/main/java/com/example/demo/api/model/FilialEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/FilialEntity.java
@@ -11,7 +11,9 @@ import java.util.List;
 public class FilialEntity {
 
     @Id
-    @Column(name = "CODIGO_FILIAL")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CODIGO_FILIAL", nullable = false, updatable = false,
+            columnDefinition = "INT AUTO_INCREMENT")
     private Integer idLancamento;
 
     @Column(name = "NOME_FILIAL", nullable = false, length = 150)

--- a/springboot/demo/src/main/java/com/example/demo/api/model/MaterialConstrucaoEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/MaterialConstrucaoEntity.java
@@ -11,7 +11,8 @@ public class MaterialConstrucaoEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CODIGO_MATERIAL")
+    @Column(name = "CODIGO_MATERIAL", nullable = false, updatable = false,
+            columnDefinition = "INT AUTO_INCREMENT")
     private Integer codMaterial;
 
     @Column(name = "CODIGO_PRODUTO", length = 50, nullable = false)

--- a/springboot/demo/src/main/java/com/example/demo/api/service/FilialService.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/service/FilialService.java
@@ -70,12 +70,13 @@ public class FilialService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Dados da filial são obrigatórios");
         }
 
+        Integer dtoId = normalizarId(dto.getIdLancamento());
+
         if (entity.getIdLancamento() == null) {
-            if (dto.getIdLancamento() == null) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Código da filial é obrigatório");
+            if (dtoId != null) {
+                entity.setIdLancamento(dtoId);
             }
-            entity.setIdLancamento(dto.getIdLancamento());
-        } else if (dto.getIdLancamento() != null && !entity.getIdLancamento().equals(dto.getIdLancamento())) {
+        } else if (dtoId != null && !entity.getIdLancamento().equals(dtoId)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Não é permitido alterar o código da filial");
         }
 
@@ -84,6 +85,13 @@ public class FilialService {
         }
 
         entity.setNome(dto.getNome());
+    }
+
+    private Integer normalizarId(Integer id) {
+        if (id == null || id <= 0) {
+            return null;
+        }
+        return id;
     }
 
     private FilialResumoDTO mapearParaResumo(FilialEntity entity) {


### PR DESCRIPTION
## Summary
- ignore non-positive identifiers when creating filiais so the database auto-increment generates the primary key
- keep preventing identifier changes during updates while allowing optional explicit ids

## Testing
- ./mvnw test *(fails: Network is unreachable while downloading Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d84964a8088320be5995fa1c973a5e