### PR TITLE
Fix JPA table naming and driver configuration

### DIFF
--- a/springboot/demo/src/main/resources/application.properties
+++ b/springboot/demo/src/main/resources/application.properties
@@ -4,13 +4,17 @@ server.port=8089
 spring.datasource.url=jdbc:mysql://localhost:3306/dbspringboot
 spring.datasource.username=root
 spring.datasource.password=root
-spring.datasource.driver-class-name = com.mysql.jdbc.Driver
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-#Usar o create s� na primeira vez que for criar o banco
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-#spring.jpa.hibernate.ddl-auto=create-drop
+#Usar o create só na primeira vez que for criar o banco
 spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.hibernate.ddl-auto=create-drop
 #spring.jpa.hibernate.ddl-auto=none
 
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# Garante que os nomes das tabelas e colunas respeitem exatamente o que foi
+# definido nas anotações das entidades, evitando a conversão automática para
+# letras minúsculas ao utilizar o Hibernate 6.
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl


### PR DESCRIPTION
## Summary
- use the current MySQL JDBC driver class name compatible with Spring Boot 3
- configure Hibernate to keep the table names defined in the entity annotations to avoid lowercase conversion

## Testing
- not run (database not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d85151408883209cd695aa6d99b09c