### PR TITLE
Adiciona script SQL para garantir criação das tabelas

### DIFF
--- a/springboot/demo/src/main/java/com/example/demo/api/model/FerramentaEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/FerramentaEntity.java
@@ -6,34 +6,34 @@ import lombok.*;
 
 @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
 @Entity
-@Table(name = "TB_FERRAMENTA")
+@Table(name = "tb_ferramenta")
 public class FerramentaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CODIGO_FERRAMENTA", nullable = false, updatable = false,
+    @Column(name = "codigo_ferramenta", nullable = false, updatable = false,
             columnDefinition = "INT AUTO_INCREMENT")
     private Integer codFerramenta;
 
-    @Column(name = "CODIGO_PRODUTO", length = 50, nullable = false)
+    @Column(name = "codigo_produto", length = 50, nullable = false)
     private String codigoProduto;
 
-    @Column(name = "VALOR", nullable = false)
+    @Column(name = "valor", nullable = false)
     private Double valor;
 
-    @Column(name = "MARCA", length = 100)
+    @Column(name = "marca", length = 100)
     private String marca;
 
-    @Column(name = "NOME", length = 150, nullable = false)
+    @Column(name = "nome", length = 150, nullable = false)
     private String nome;
 
-    @Column(name = "QTD_PACOTE")
+    @Column(name = "qtd_pacote")
     private Integer qtdPacote;
 
 
     @JsonBackReference("filial-ferramentas")
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "CODIGO_FILIAL", nullable = false,
-            foreignKey = @ForeignKey(name = "FK_FERRAMENTA_FILIAL"))
+    @JoinColumn(name = "codigo_filial", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ferramenta_filial"))
     private FilialEntity filial;
 }

--- a/springboot/demo/src/main/java/com/example/demo/api/model/FilialEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/FilialEntity.java
@@ -7,16 +7,16 @@ import java.util.List;
 
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 @Entity
-@Table(name = "TB_FILIAL")
+@Table(name = "tb_filial")
 public class FilialEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CODIGO_FILIAL", nullable = false, updatable = false,
+    @Column(name = "codigo_filial", nullable = false, updatable = false,
             columnDefinition = "INT AUTO_INCREMENT")
     private Integer idLancamento;
 
-    @Column(name = "NOME_FILIAL", nullable = false, length = 150)
+    @Column(name = "nome_filial", nullable = false, length = 150)
     private String nome;
 
     @JsonManagedReference("filial-ferramentas")

--- a/springboot/demo/src/main/java/com/example/demo/api/model/MaterialConstrucaoEntity.java
+++ b/springboot/demo/src/main/java/com/example/demo/api/model/MaterialConstrucaoEntity.java
@@ -6,34 +6,34 @@ import lombok.*;
 
 @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
 @Entity
-@Table(name = "TB_MATERIAL_CONSTRUCAO")
+@Table(name = "tb_material_construcao")
 public class MaterialConstrucaoEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CODIGO_MATERIAL", nullable = false, updatable = false,
+    @Column(name = "codigo_material", nullable = false, updatable = false,
             columnDefinition = "INT AUTO_INCREMENT")
     private Integer codMaterial;
 
-    @Column(name = "CODIGO_PRODUTO", length = 50, nullable = false)
+    @Column(name = "codigo_produto", length = 50, nullable = false)
     private String codigoProduto;
 
-    @Column(name = "VALOR", nullable = false)
+    @Column(name = "valor", nullable = false)
     private Double valor;
 
-    @Column(name = "COR", length = 50)
+    @Column(name = "cor", length = 50)
     private String cor;
 
-    @Column(name = "NOME", length = 150, nullable = false)
+    @Column(name = "nome", length = 150, nullable = false)
     private String nome;
 
-    @Column(name = "MATERIA_PRIMA", length = 100)
+    @Column(name = "materia_prima", length = 100)
     private String materiaPrima;
 
     // relação com filial
     @JsonBackReference("filial-materiais")
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "CODIGO_FILIAL", nullable = false,
-            foreignKey = @ForeignKey(name = "FK_MATERIAL_FILIAL"))
+    @JoinColumn(name = "codigo_filial", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_material_filial"))
     private FilialEntity filial;
 }

--- a/springboot/demo/src/main/resources/application.properties
+++ b/springboot/demo/src/main/resources/application.properties
@@ -15,6 +15,10 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 # Garante que os nomes das tabelas e colunas respeitem exatamente o que foi
-# definido nas anotações das entidades, evitando a conversão automática para
-# letras minúsculas ao utilizar o Hibernate 6.
+# definido nas anotações das entidades durante a geração do esquema.
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+# Executa o script schema.sql em qualquer ambiente e garante que ele seja
+# processado antes do Hibernate validar ou atualizar o esquema.
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true

--- a/springboot/demo/src/main/resources/schema.sql
+++ b/springboot/demo/src/main/resources/schema.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS tb_filial (
+    codigo_filial INT AUTO_INCREMENT PRIMARY KEY,
+    nome_filial VARCHAR(150) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tb_material_construcao (
+    codigo_material INT AUTO_INCREMENT PRIMARY KEY,
+    codigo_produto VARCHAR(50) NOT NULL,
+    valor DOUBLE NOT NULL,
+    cor VARCHAR(50),
+    nome VARCHAR(150) NOT NULL,
+    materia_prima VARCHAR(100),
+    codigo_filial INT NOT NULL,
+    CONSTRAINT fk_material_filial FOREIGN KEY (codigo_filial)
+        REFERENCES tb_filial (codigo_filial)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tb_ferramenta (
+    codigo_ferramenta INT AUTO_INCREMENT PRIMARY KEY,
+    codigo_produto VARCHAR(50) NOT NULL,
+    valor DOUBLE NOT NULL,
+    marca VARCHAR(100),
+    nome VARCHAR(150) NOT NULL,
+    qtd_pacote INT,
+    codigo_filial INT NOT NULL,
+    CONSTRAINT fk_ferramenta_filial FOREIGN KEY (codigo_filial)
+        REFERENCES tb_filial (codigo_filial)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- adiciona um schema.sql com a criação das tabelas de filial, ferramentas e materiais usando nomes compatíveis com MySQL
- configura a aplicação para executar o script sempre na inicialização, antes do Hibernate ajustar o esquema

## Testing
- not run (ambiente requer banco MySQL para validar a criação das tabelas)


------
https://chatgpt.com/codex/tasks/task_e_68d8531d4e048320a47f4df32fb28a3a