### PR TITLE
Add skipped service tests

### DIFF
--- a/springboot/demo/src/test/java/com/example/demo/api/service/FerramentaServiceTest.java
+++ b/springboot/demo/src/test/java/com/example/demo/api/service/FerramentaServiceTest.java
@@ -1,0 +1,111 @@
+package com.example.demo.api.service;
+
+import com.example.demo.api.dto.FerramentaDTO;
+import com.example.demo.api.dto.FilialResumoDTO;
+import com.example.demo.api.model.FerramentaEntity;
+import com.example.demo.api.model.FilialEntity;
+import com.example.demo.api.repository.FerramentaRepository;
+import com.example.demo.api.repository.FilialRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FerramentaServiceTest {
+
+    @Mock
+    private FerramentaRepository ferramentaRepository;
+
+    @Mock
+    private FilialRepository filialRepository;
+
+    private FerramentaService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FerramentaService(ferramentaRepository, filialRepository);
+    }
+
+    @Test
+    @Disabled("Skipped by request")
+    void listarTodosDeveRetornarFerramentasMapeadas() {
+        FilialEntity filial = FilialEntity.builder()
+                .idLancamento(2)
+                .nome("Unidade Sul")
+                .build();
+
+        FerramentaEntity entity = FerramentaEntity.builder()
+                .codFerramenta(30)
+                .codigoProduto("FER-001")
+                .valor(129.9)
+                .marca("Tools")
+                .nome("Parafusadeira")
+                .qtdPacote(2)
+                .filial(filial)
+                .build();
+
+        when(ferramentaRepository.findAll()).thenReturn(List.of(entity));
+
+        List<FerramentaDTO> resultado = service.listarTodos();
+
+        assertThat(resultado)
+                .singleElement()
+                .satisfies(dto -> {
+                    assertThat(dto.getCodFerramenta()).isEqualTo(30);
+                    assertThat(dto.getFilial()).isNotNull();
+                    assertThat(dto.getFilial().getNome()).isEqualTo("Unidade Sul");
+                });
+    }
+
+    @Test
+    @Disabled("Skipped by request")
+    void criarDeveSalvarFerramentaComFilialValida() {
+        FilialResumoDTO filialResumo = FilialResumoDTO.builder()
+                .idLancamento(9)
+                .nome("Unidade Leste")
+                .build();
+
+        FerramentaDTO dto = FerramentaDTO.builder()
+                .codigoProduto("FER-020")
+                .valor(59.9)
+                .marca("Max")
+                .nome("Martelo")
+                .qtdPacote(4)
+                .filial(filialResumo)
+                .build();
+
+        FilialEntity filialEntity = FilialEntity.builder()
+                .idLancamento(9)
+                .nome("Unidade Leste")
+                .build();
+
+        when(filialRepository.findById(9)).thenReturn(Optional.of(filialEntity));
+        when(ferramentaRepository.save(any(FerramentaEntity.class))).thenAnswer(invocation -> {
+            FerramentaEntity salvo = invocation.getArgument(0);
+            salvo.setCodFerramenta(41);
+            return salvo;
+        });
+
+        FerramentaDTO resultado = service.criar(dto);
+
+        ArgumentCaptor<FerramentaEntity> captor = ArgumentCaptor.forClass(FerramentaEntity.class);
+        verify(ferramentaRepository).save(captor.capture());
+
+        FerramentaEntity salvo = captor.getValue();
+        assertThat(salvo.getFilial()).isEqualTo(filialEntity);
+        assertThat(resultado.getCodFerramenta()).isEqualTo(41);
+        assertThat(resultado.getFilial().getIdLancamento()).isEqualTo(9);
+    }
+}

--- a/springboot/demo/src/test/java/com/example/demo/api/service/FilialServiceTest.java
+++ b/springboot/demo/src/test/java/com/example/demo/api/service/FilialServiceTest.java
@@ -1,0 +1,102 @@
+package com.example.demo.api.service;
+
+import com.example.demo.api.dto.FerramentaDTO;
+import com.example.demo.api.dto.FilialDetalheDTO;
+import com.example.demo.api.dto.FilialResumoDTO;
+import com.example.demo.api.dto.MaterialConstrucaoDTO;
+import com.example.demo.api.model.FerramentaEntity;
+import com.example.demo.api.model.FilialEntity;
+import com.example.demo.api.model.MaterialConstrucaoEntity;
+import com.example.demo.api.repository.FilialRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FilialServiceTest {
+
+    @Mock
+    private FilialRepository filialRepository;
+
+    private FilialService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FilialService(filialRepository);
+    }
+
+    @Test
+    @Disabled("Skipped by request")
+    void listarTodasDeveRetornarResumoDasFiliais() {
+        FilialEntity entity = FilialEntity.builder()
+                .idLancamento(3)
+                .nome("Loja Centro")
+                .build();
+
+        when(filialRepository.findAll()).thenReturn(List.of(entity));
+
+        List<FilialResumoDTO> resultado = service.listarTodas();
+
+        assertThat(resultado)
+                .singleElement()
+                .satisfies(resumo -> {
+                    assertThat(resumo.getIdLancamento()).isEqualTo(3);
+                    assertThat(resumo.getNome()).isEqualTo("Loja Centro");
+                });
+    }
+
+    @Test
+    @Disabled("Skipped by request")
+    void buscarPorIdDeveRetornarDetalhesComAssociacoes() {
+        FilialEntity filial = FilialEntity.builder()
+                .idLancamento(5)
+                .nome("Loja Norte")
+                .build();
+
+        FerramentaEntity ferramenta = FerramentaEntity.builder()
+                .codFerramenta(11)
+                .codigoProduto("FER-010")
+                .valor(79.9)
+                .marca("ACME")
+                .nome("Furadeira")
+                .qtdPacote(1)
+                .filial(filial)
+                .build();
+
+        MaterialConstrucaoEntity material = MaterialConstrucaoEntity.builder()
+                .codMaterial(12)
+                .codigoProduto("MAT-010")
+                .valor(24.5)
+                .cor("Cinza")
+                .nome("Cimento")
+                .materiaPrima("Calcário")
+                .filial(filial)
+                .build();
+
+        filial.setFerramentas(List.of(ferramenta));
+        filial.setMateriais(List.of(material));
+
+        when(filialRepository.findById(5)).thenReturn(Optional.of(filial));
+
+        Optional<FilialDetalheDTO> resultado = service.buscarPorId(5);
+
+        assertThat(resultado).isPresent();
+        FilialDetalheDTO detalhe = resultado.orElseThrow();
+        assertThat(detalhe.getNome()).isEqualTo("Loja Norte");
+        assertThat(detalhe.getFerramentas())
+                .map(FerramentaDTO::getNome)
+                .containsExactly("Furadeira");
+        assertThat(detalhe.getMateriais())
+                .map(MaterialConstrucaoDTO::getNome)
+                .containsExactly("Cimento");
+    }
+}

--- a/springboot/demo/src/test/java/com/example/demo/api/service/MaterialConstrucaoServiceTest.java
+++ b/springboot/demo/src/test/java/com/example/demo/api/service/MaterialConstrucaoServiceTest.java
@@ -1,0 +1,112 @@
+package com.example.demo.api.service;
+
+import com.example.demo.api.dto.FilialResumoDTO;
+import com.example.demo.api.dto.MaterialConstrucaoDTO;
+import com.example.demo.api.model.FilialEntity;
+import com.example.demo.api.model.MaterialConstrucaoEntity;
+import com.example.demo.api.repository.FilialRepository;
+import com.example.demo.api.repository.MaterialConstrucaoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MaterialConstrucaoServiceTest {
+
+    @Mock
+    private MaterialConstrucaoRepository materialConstrucaoRepository;
+
+    @Mock
+    private FilialRepository filialRepository;
+
+    private MaterialConstrucaoService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MaterialConstrucaoService(materialConstrucaoRepository, filialRepository);
+    }
+
+    @Test
+    @Disabled("Skipped by request")
+    void listarTodosDeveMapearEntidadesParaDTOs() {
+        FilialEntity filial = FilialEntity.builder()
+                .idLancamento(1)
+                .nome("Matriz")
+                .build();
+
+        MaterialConstrucaoEntity entity = MaterialConstrucaoEntity.builder()
+                .codMaterial(10)
+                .codigoProduto("MAT-001")
+                .valor(19.9)
+                .cor("Azul")
+                .nome("Tinta")
+                .materiaPrima("Pigmento")
+                .filial(filial)
+                .build();
+
+        when(materialConstrucaoRepository.findAll()).thenReturn(List.of(entity));
+
+        List<MaterialConstrucaoDTO> resultado = service.listarTodos();
+
+        assertThat(resultado)
+                .singleElement()
+                .satisfies(dto -> {
+                    assertThat(dto.getCodMaterial()).isEqualTo(10);
+                    assertThat(dto.getCodigoProduto()).isEqualTo("MAT-001");
+                    assertThat(dto.getFilial()).isNotNull();
+                    assertThat(dto.getFilial().getNome()).isEqualTo("Matriz");
+                });
+    }
+
+    @Test
+    @Disabled("Skipped by request")
+    void criarDevePersistirMaterialComFilialExistente() {
+        FilialResumoDTO filialResumo = FilialResumoDTO.builder()
+                .idLancamento(7)
+                .nome("Centro")
+                .build();
+
+        MaterialConstrucaoDTO dto = MaterialConstrucaoDTO.builder()
+                .codigoProduto("MAT-002")
+                .valor(49.9)
+                .cor("Vermelho")
+                .nome("Primer")
+                .materiaPrima("Resina")
+                .filial(filialResumo)
+                .build();
+
+        FilialEntity filialEntity = FilialEntity.builder()
+                .idLancamento(7)
+                .nome("Centro")
+                .build();
+
+        when(filialRepository.findById(7)).thenReturn(Optional.of(filialEntity));
+        when(materialConstrucaoRepository.save(any(MaterialConstrucaoEntity.class))).thenAnswer(invocation -> {
+            MaterialConstrucaoEntity salvo = invocation.getArgument(0);
+            salvo.setCodMaterial(22);
+            return salvo;
+        });
+
+        MaterialConstrucaoDTO resultado = service.criar(dto);
+
+        ArgumentCaptor<MaterialConstrucaoEntity> captor = ArgumentCaptor.forClass(MaterialConstrucaoEntity.class);
+        verify(materialConstrucaoRepository).save(captor.capture());
+
+        MaterialConstrucaoEntity salvo = captor.getValue();
+        assertThat(salvo.getFilial()).isEqualTo(filialEntity);
+        assertThat(resultado.getCodMaterial()).isEqualTo(22);
+        assertThat(resultado.getFilial().getIdLancamento()).isEqualTo(7);
+    }
+}


### PR DESCRIPTION
## Summary
- add Mockito-based unit test scaffolding for the material, filial, and ferramenta services
- annotate each test with @Disabled so they are skipped during execution as requested

## Testing
- `./mvnw test` *(fails: Maven wrapper could not download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d85844b5c08320978623c0666fe4f8