### PR TITLE
Add Docker Compose environment for API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+
+services:
+  api:
+    build:
+      context: ./springboot/demo
+    ports:
+      - "8089:8089"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/dbspringboot?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+      TZ: UTC
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: dbspringboot
+      TZ: UTC
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  db_data:

--- a/springboot/demo/.dockerignore
+++ b/springboot/demo/.dockerignore
@@ -1,0 +1,19 @@
+# Maven
+.mvn/
+mvnw
+mvnw.cmd
+
+# Build output
+target/
+
+# IDE/editor artifacts
+.idea/
+.vscode/
+*.iml
+
+# Git metadata
+.git
+.gitignore
+
+# Misc
+Dockerfile.*


### PR DESCRIPTION
## Summary
- add a Docker Compose stack with the API service and a MySQL database
- create a Docker ignore file to keep build cache light when building the API image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d87d38ef108320b6730174e15008af