### PR TITLE
Enable schema.sql execution for table creation

### DIFF
--- a/springboot/demo/src/main/resources/application.properties
+++ b/springboot/demo/src/main/resources/application.properties
@@ -14,5 +14,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-spring.sql.init.mode=never
+# Executa sempre o schema.sql para garantir a criação das tabelas dependentes
+spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true


### PR DESCRIPTION
## Summary
- configure Spring Boot to always run schema.sql during startup
- ensure all dependent tables such as materiais and ferramentas are created alongside tb_filial

## Testing
- not run (network restricted environment prevented Maven wrapper download)

------
https://chatgpt.com/codex/tasks/task_e_68d8990e94d88320bef627baf4bf56cc